### PR TITLE
Fixed a small typo which MIGHT cause confusion

### DIFF
--- a/AuthPermissions.AspNetCore/JwtTokenCode/TokenBuilder.cs
+++ b/AuthPermissions.AspNetCore/JwtTokenCode/TokenBuilder.cs
@@ -17,7 +17,7 @@ using Microsoft.IdentityModel.Tokens;
 namespace AuthPermissions.AspNetCore.JwtTokenCode
 {
     /// <summary>
-    /// This contains the code to create/refresh JST tokens
+    /// This contains the code to create/refresh JWT tokens
     /// </summary>
     public class TokenBuilder : ITokenBuilder
     {


### PR DESCRIPTION
The summary of the class **AuthPermissions.AspNetCore/JwtTokenCode/TokenBuilder.cs** had a small typo saying JST instead of JWT. 