### PR TITLE
Fixed a bug where TenantRoles would give an exception if the _tenantRoles was null

### DIFF
--- a/AuthPermissions.AspNetCore/CreateNuGetRelease.nuspec
+++ b/AuthPermissions.AspNetCore/CreateNuGetRelease.nuspec
@@ -2,7 +2,7 @@
 <package xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>AuthPermissions.AspNetCore</id>
-    <version>3.2.0</version>
+    <version>3.2.1-dev1</version>
     <authors>Jon P Smith</authors>
     <product>AuthPermissions.AspNetCore</product>
     <copyright>Copyright (c) 2021 Jon P Smith</copyright>

--- a/AuthPermissions.AspNetCore/MultiProjPack.xml
+++ b/AuthPermissions.AspNetCore/MultiProjPack.xml
@@ -4,7 +4,7 @@
   <!-- See documentation for all the possible values -->
   <metadata>
     <id>AuthPermissions.AspNetCore</id>
-    <version>3.2.0</version>
+    <version>3.2.1-dev1</version>
     <authors>Jon P Smith</authors>
     <product>AuthPermissions.AspNetCore</product>
     <copyright>Copyright (c) 2021 Jon P Smith</copyright>

--- a/AuthPermissions.BaseCode/DataLayer/Classes/Tenant.cs
+++ b/AuthPermissions.BaseCode/DataLayer/Classes/Tenant.cs
@@ -124,11 +124,11 @@ namespace AuthPermissions.BaseCode.DataLayer.Classes
         /// </summary>
         public IReadOnlyCollection<Tenant> Children => _children?.ToList();
 
+
         /// <summary>
         /// This holds any Roles that have been specifically 
         /// </summary>
-        public IReadOnlyCollection<RoleToPermissions> TenantRoles => _tenantRoles.ToList();
-
+        public IReadOnlyCollection<RoleToPermissions> TenantRoles => _tenantRoles?.ToList() ?? new List<RoleToPermissions>();
         /// <summary>
         /// Easy way to see the tenant and its key
         /// </summary>


### PR DESCRIPTION
The TenantRoles would give an exception if the Tenant has no roles yet, since it calls .ToList() on something that may very well be null in this case.

Not sure if this is the right branch to merge into, maybe `dev` would be a better fit?